### PR TITLE
Optional manifest fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         run: "tar cvf ${{ github.event.repository.name }}.tar.gz -C /__w/raceboat/raceboat/ ./racesdk"
 
       - name: Upload Build Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "${{ github.event.repository.name }}.tar.gz"
           path: "${{ github.event.repository.name }}.tar.gz"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download Framework Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: "${{ github.event.repository.name }}.tar.gz"
 
@@ -179,7 +179,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download Framework Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: "${{ github.event.repository.name }}.tar.gz"
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ docker run -it --rm --name=build-pt \
 pushd raceboat-compile-image && \
 ./build_image.sh -n ghcr.io/tst-race/raceboat --platform-x86_64 && \
 popd && \
-pushd runtime-image && \
+pushd raceboat-runtime-image && \
 ./build_image.sh -n ghcr.io/tst-race/raceboat --platform-x86_64 && \
 popd
 ```

--- a/include/race/common/ChannelProperties.h
+++ b/include/race/common/ChannelProperties.h
@@ -138,12 +138,12 @@ public:
    * @brief List of hint names supported by this channel
    *
    */
-  std::vector<std::string> supported_hints;
+  std::vector<std::string> supportedHints;
 
   int maxLinks;
 
-  int creatorsPerLoader;
-  int loadersPerCreator;
+  int maxCreatorsPerLoader;
+  int maxLoadersPerCreator;
 
   std::vector<ChannelRole> roles;
 
@@ -195,10 +195,10 @@ inline bool operator==(const ChannelProperties &a, const ChannelProperties &b) {
          a.loaderExpected == b.loaderExpected &&
          a.creatorExpected == b.creatorExpected && a.mtu == b.mtu &&
          a.reliable == b.reliable && a.duration_s == b.duration_s &&
-         a.period_s == b.period_s && a.supported_hints == b.supported_hints &&
+         a.period_s == b.period_s && a.supportedHints == b.supportedHints &&
          a.multiAddressable == b.multiAddressable && a.maxLinks == b.maxLinks &&
-         a.creatorsPerLoader == b.creatorsPerLoader &&
-         a.loadersPerCreator == b.loadersPerCreator && a.roles == b.roles &&
+         a.maxCreatorsPerLoader == b.maxCreatorsPerLoader &&
+         a.maxLoadersPerCreator == b.maxLoadersPerCreator && a.roles == b.roles &&
          a.currentRole == b.currentRole &&
          a.maxSendsPerInterval == b.maxSendsPerInterval &&
          a.secondsPerInterval == b.secondsPerInterval &&

--- a/raceboat-runtime-image/build_image.sh
+++ b/raceboat-runtime-image/build_image.sh
@@ -201,7 +201,7 @@ eval DOCKER_BUILDKIT=1 docker buildx build \
     --no-cache \
     --rm \
     -f "${DIR}/Dockerfile" \
-    -t "${IMAGE_NAMESPACE}raceboat:${IMAGE_VERSION}" \
+    -t "${IMAGE_NAMESPACE}raceboat-runtime:${IMAGE_VERSION}" \
     --load \
     --progress=plain \
     $PUSH_OPTION \

--- a/source/plugin-loading/ComponentPlugin.cpp
+++ b/source/plugin-loading/ComponentPlugin.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+#include "FileSystem.h"
 #include "ComponentPlugin.h"
 
 namespace Raceboat {
@@ -61,7 +62,8 @@ ComponentPlugin::createTransport(const std::string &name, ITransportSdk *sdk,
                                  PluginConfig &pluginConfig) {
   TRACE_METHOD(path, name);
   initTransport();
-  pluginConfig.pluginDirectory = path;
+  fs::path pluginDirectory = path;
+  pluginConfig.pluginDirectory = pluginDirectory.remove_filename().c_str();
   ITransportComponent *transport =
       createTransportImpl(name.c_str(), sdk, roleName.c_str(), pluginConfig);
   return std::shared_ptr<ITransportComponent>(transport, destroyTransportImpl);
@@ -73,7 +75,8 @@ ComponentPlugin::createUserModel(const std::string &name, IUserModelSdk *sdk,
                                  PluginConfig &pluginConfig) {
   TRACE_METHOD(path, name);
   initUserModel();
-  pluginConfig.pluginDirectory = path;
+  fs::path pluginDirectory = path;
+  pluginConfig.pluginDirectory = pluginDirectory.remove_filename().c_str();
   return std::shared_ptr<IUserModelComponent>(
       createUserModelImpl(name.c_str(), sdk, roleName.c_str(), pluginConfig),
       destroyUserModelImpl);
@@ -85,7 +88,8 @@ ComponentPlugin::createEncoding(const std::string &name, IEncodingSdk *sdk,
                                 PluginConfig &pluginConfig) {
   TRACE_METHOD(path, name);
   initEncoding();
-  const std::string pluginPath = path;
+  fs::path pluginDirectory = path;
+  pluginConfig.pluginDirectory = pluginDirectory.remove_filename().c_str();
   return std::shared_ptr<IEncodingComponent>(
       createEncodingImpl(name.c_str(), sdk, roleName.c_str(), pluginConfig),
       destroyEncodingImpl);

--- a/source/plugin-loading/ComponentPlugin.h
+++ b/source/plugin-loading/ComponentPlugin.h
@@ -25,6 +25,8 @@
 #include "race/decomposed/ITransportComponent.h"
 #include "race/decomposed/IUserModelComponent.h"
 
+namespace fs = std::filesystem;
+
 namespace Raceboat {
 
 struct ComponentPlugin : public IComponentPlugin {


### PR DESCRIPTION
Make most manifest fields optional, since they are not actually used in current Raceboat logic, and put unnecessary demands / verbosity on channel developers.